### PR TITLE
Dynamic factors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ fail_fast: true
 
 repos:
   - repo: https://github.com/crate-ci/typos
-    rev: v1.22.9
+    rev: v1.24.1
     hooks:
       - id: typos
   - repo: local

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -144,11 +144,25 @@ impl SignaturesCollector {
         Continue
     }
 
+    fn should_neglect_factors_due_to_irrelevant(
+        &self,
+        factor_sources_of_kind: &FactorSourcesOfKind,
+    ) -> bool {
+        let state = self.state.borrow();
+        let petitions = state.petitions.borrow();
+        petitions.should_neglect_factors_due_to_irrelevant(factor_sources_of_kind)
+    }
+
     fn neglected_factors_due_to_irrelevant(
         &self,
         factor_sources_of_kind: &FactorSourcesOfKind,
     ) -> bool {
-        false
+        if self.should_neglect_factors_due_to_irrelevant(factor_sources_of_kind) {
+            self.process_batch_response(SignWithFactorsOutcome::irrelevant(factor_sources_of_kind));
+            true
+        } else {
+            false
+        }
     }
 
     async fn sign_with_factors_of_kind(&self, factor_sources_of_kind: &FactorSourcesOfKind) {

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -158,6 +158,10 @@ impl SignaturesCollector {
         factor_sources_of_kind: &FactorSourcesOfKind,
     ) -> bool {
         if self.should_neglect_factors_due_to_irrelevant(factor_sources_of_kind) {
+            info!(
+                "Neglecting all factors of kind: {} since they are all irrelevant (all TX referencing those factors have already failed)",
+                factor_sources_of_kind.kind
+            );
             self.process_batch_response(SignWithFactorsOutcome::irrelevant(factor_sources_of_kind));
             true
         } else {

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -470,6 +470,28 @@ mod tests {
     }
 
     #[test]
+    fn factor_source_kinds_order() {
+        let kinds = HDFactorSource::all()
+            .into_iter()
+            .map(|f| f.factor_source_kind())
+            .collect::<IndexSet<_>>();
+        let mut kinds = kinds.into_iter().collect_vec();
+        kinds.sort();
+        let kinds = kinds.into_iter().collect::<IndexSet<_>>();
+        assert_eq!(
+            kinds,
+            IndexSet::<FactorSourceKind>::from_iter([
+                FactorSourceKind::Ledger,
+                FactorSourceKind::Arculus,
+                FactorSourceKind::Yubikey,
+                FactorSourceKind::SecurityQuestions,
+                FactorSourceKind::OffDeviceMnemonic,
+                FactorSourceKind::Device,
+            ])
+        )
+    }
+
+    #[test]
     fn test_profile() {
         let factor_sources = &HDFactorSource::all();
         let a0 = &Account::a0();

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -296,11 +296,6 @@ impl SignaturesCollector {
         let invalid_transactions_if_neglected =
             self.invalid_transactions_if_neglected_factor_sources(factor_source_ids);
 
-        info!(
-            "Invalid if neglected: {:?}",
-            invalid_transactions_if_neglected
-        );
-
         // Prepare the request for the interactor
         ParallelBatchSigningRequest::new(per_factor_source, invalid_transactions_if_neglected)
     }

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -144,7 +144,20 @@ impl SignaturesCollector {
         Continue
     }
 
-    async fn sign_with_factors_of_kind(&self, factor_sources_of_kind: FactorSourcesOfKind) {
+    fn neglected_factors_due_to_irrelevant(
+        &self,
+        factor_sources_of_kind: &FactorSourcesOfKind,
+    ) -> bool {
+        false
+    }
+
+    async fn sign_with_factors_of_kind(&self, factor_sources_of_kind: &FactorSourcesOfKind) {
+        info!(
+            "Use(?) #{:?} factors of kind: {:?}",
+            &factor_sources_of_kind.factor_sources().len(),
+            &factor_sources_of_kind.kind
+        );
+
         let interactor = self
             .dependencies
             .interactors
@@ -212,15 +225,13 @@ impl SignaturesCollector {
     /// In decreasing "friction order"
     async fn sign_with_factors(&self) -> Result<()> {
         let factors_of_kind = self.dependencies.factors_of_kind.clone();
-        for factor_sources_of_kind in factors_of_kind.into_iter() {
+        for factor_sources_of_kind in factors_of_kind.iter() {
             if self.continuation() == FinishEarly {
                 break;
             }
-            info!(
-                "Use(?) #{:?} factors of kind: {:?}",
-                &factor_sources_of_kind.factor_sources().len(),
-                &factor_sources_of_kind.kind
-            );
+            if self.neglected_factors_due_to_irrelevant(factor_sources_of_kind) {
+                continue;
+            }
             self.sign_with_factors_of_kind(factor_sources_of_kind).await;
         }
         info!("FINISHED WITH ALL FACTORS");

--- a/src/signing/collector/signatures_collector.rs
+++ b/src/signing/collector/signatures_collector.rs
@@ -274,7 +274,7 @@ impl SignaturesCollector {
                 *factor_source_id,
             ]))
             .into_iter()
-            .collect_vec(),
+            .collect::<IndexSet<_>>(),
         )
     }
 

--- a/src/signing/collector/signing_finish_early_strategy.rs
+++ b/src/signing/collector/signing_finish_early_strategy.rs
@@ -14,7 +14,7 @@ pub struct WhenSomeTransactionIsInvalid(pub SignaturesCollectingContinuation);
 
 impl Default for WhenSomeTransactionIsInvalid {
     fn default() -> Self {
-        Self(SignaturesCollectingContinuation::FinishEarly)
+        Self(SignaturesCollectingContinuation::Continue)
     }
 }
 
@@ -54,6 +54,19 @@ mod tests {
         assert_eq!(
             sut.when_all_transactions_are_valid.0,
             SignaturesCollectingContinuation::Continue
+        );
+        assert_eq!(
+            sut.when_some_transaction_is_invalid.0,
+            SignaturesCollectingContinuation::Continue
+        );
+    }
+
+    #[test]
+    fn test_default_is_finish_when_valid_continue_if_invalid() {
+        let sut = Sut::default();
+        assert_eq!(
+            sut.when_all_transactions_are_valid.0,
+            SignaturesCollectingContinuation::FinishEarly
         );
         assert_eq!(
             sut.when_some_transaction_is_invalid.0,

--- a/src/signing/interactors/batch_tx_batch_key_signing_request.rs
+++ b/src/signing/interactors/batch_tx_batch_key_signing_request.rs
@@ -121,6 +121,9 @@ pub struct BatchTXBatchKeySigningRequest {
 impl BatchTXBatchKeySigningRequest {
     /// # Panics
     /// Panics if `per_transaction` is empty
+    ///
+    /// Also panics if `per_transaction` if the factor source id
+    /// of each request does not match `factor_source_id`.
     pub fn new(
         factor_source_id: FactorSourceIDFromHash,
         per_transaction: IndexSet<BatchKeySigningRequest>,
@@ -129,9 +132,11 @@ impl BatchTXBatchKeySigningRequest {
             !per_transaction.is_empty(),
             "Invalid input. No transaction to sign, this is a programmer error."
         );
+
         assert!(per_transaction
             .iter()
             .all(|f| f.factor_source_id == factor_source_id), "Discprepancy! Input for one of the transactions has a mismatching FactorSourceID, this is a programmer error.");
+
         Self {
             factor_source_id,
             per_transaction: per_transaction.into_iter().collect(),

--- a/src/signing/interactors/batch_tx_batch_key_signing_request.rs
+++ b/src/signing/interactors/batch_tx_batch_key_signing_request.rs
@@ -137,6 +137,10 @@ impl BatchTXBatchKeySigningRequest {
             per_transaction: per_transaction.into_iter().collect(),
         }
     }
+
+    pub fn factor_source_kind(&self) -> FactorSourceKind {
+        self.factor_source_id.kind
+    }
 }
 
 impl HasSampleValues for BatchTXBatchKeySigningRequest {

--- a/src/signing/interactors/parallel_batch_signing_request.rs
+++ b/src/signing/interactors/parallel_batch_signing_request.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 /// A collection of factor sources to use to sign, transactions with multiple keys
 /// (derivations paths).
-#[derive(derive_more::Debug)]
+#[derive(derive_more::Debug, Clone)]
 #[debug("per_factor_source: {:#?}", per_factor_source)]
 pub struct ParallelBatchSigningRequest {
     factor_source_kind: FactorSourceKind,

--- a/src/signing/interactors/parallel_batch_signing_request.rs
+++ b/src/signing/interactors/parallel_batch_signing_request.rs
@@ -5,6 +5,8 @@ use crate::prelude::*;
 #[derive(derive_more::Debug)]
 #[debug("per_factor_source: {:#?}", per_factor_source)]
 pub struct ParallelBatchSigningRequest {
+    factor_source_kind: FactorSourceKind,
+
     /// Per factor source, a set of transactions to sign, with
     /// multiple derivations paths.
     pub per_factor_source: IndexMap<FactorSourceIDFromHash, BatchTXBatchKeySigningRequest>,
@@ -15,13 +17,63 @@ pub struct ParallelBatchSigningRequest {
 }
 
 impl ParallelBatchSigningRequest {
+    /// # Panics
+    /// Panics if `per_factor_source` is empty
+    ///
+    /// Panics if not all factor sources are of the same kind
     pub fn new(
+        factor_source_kind: FactorSourceKind,
         per_factor_source: IndexMap<FactorSourceIDFromHash, BatchTXBatchKeySigningRequest>,
         invalid_transactions_if_neglected: IndexSet<InvalidTransactionIfNeglected>,
     ) -> Self {
+        assert!(
+            !per_factor_source.is_empty(),
+            "Invalid input, per_factor_source must not be empty, this is a programmer error."
+        );
+        assert!(
+            per_factor_source
+                .values()
+                .all(|f| f.factor_source_id.kind == factor_source_kind),
+            "Discrepancy! All factor sources must be of the same kind, this is a programmer error."
+        );
+
         Self {
+            factor_source_kind,
             per_factor_source,
             invalid_transactions_if_neglected,
         }
+    }
+
+    pub fn factor_source_kind(&self) -> FactorSourceKind {
+        self.factor_source_kind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    type Sut = ParallelBatchSigningRequest;
+
+    #[test]
+    #[should_panic(
+        expected = "Invalid input, per_factor_source must not be empty, this is a programmer error."
+    )]
+    fn panics_if_per_factor_source_is_empty() {
+        Sut::new(FactorSourceKind::Device, IndexMap::new(), IndexSet::new());
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Discrepancy! All factor sources must be of the same kind, this is a programmer error."
+    )]
+    fn panics_if_wrong_factor_source_kind() {
+        Sut::new(
+            FactorSourceKind::Arculus,
+            IndexMap::from_iter([(
+                FactorSourceIDFromHash::sample(),
+                BatchTXBatchKeySigningRequest::sample(),
+            )]),
+            IndexSet::new(),
+        );
     }
 }

--- a/src/signing/interactors/serial_batch_signing_request.rs
+++ b/src/signing/interactors/serial_batch_signing_request.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 /// a collection of transactions to sign with multiple keys (derivation paths),
 /// and a collection of transactions which would be invalid if the user skips
 /// signing with this factor source, or if we fail to sign.
-#[derive(derive_more::Debug)]
+#[derive(derive_more::Debug, Clone)]
 #[debug("input: {:#?}", input)]
 pub struct SerialBatchSigningRequest {
     pub input: BatchTXBatchKeySigningRequest,
@@ -22,5 +22,9 @@ impl SerialBatchSigningRequest {
             input,
             invalid_transactions_if_neglected,
         }
+    }
+
+    pub fn factor_source_kind(&self) -> FactorSourceKind {
+        self.input.factor_source_kind()
     }
 }

--- a/src/signing/interactors/serial_batch_signing_request.rs
+++ b/src/signing/interactors/serial_batch_signing_request.rs
@@ -10,13 +10,13 @@ pub struct SerialBatchSigningRequest {
     pub input: BatchTXBatchKeySigningRequest,
     /// A collection of transactions which would be invalid if the user skips
     /// signing with this factor source, or if we fail to sign
-    pub invalid_transactions_if_neglected: Vec<InvalidTransactionIfNeglected>,
+    pub invalid_transactions_if_neglected: IndexSet<InvalidTransactionIfNeglected>,
 }
 
 impl SerialBatchSigningRequest {
     pub fn new(
         input: BatchTXBatchKeySigningRequest,
-        invalid_transactions_if_neglected: Vec<InvalidTransactionIfNeglected>,
+        invalid_transactions_if_neglected: IndexSet<InvalidTransactionIfNeglected>,
     ) -> Self {
         Self {
             input,

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -65,10 +65,16 @@ impl PetitionEntity {
         )
     }
 
-    /// Returns `true` signatures requirement has been fulfilled, either by
+    /// Returns `true` if signatures requirement has been fulfilled, either by
     /// override factors or by threshold factors
     pub fn has_signatures_requirement_been_fulfilled(&self) -> bool {
         self.status() == PetitionFactorsStatus::Finished(PetitionFactorsStatusFinished::Success)
+    }
+
+    /// Returns `true` if the transaction of this petition already has failed due
+    /// to too many factors neglected
+    pub fn has_failed(&self) -> bool {
+        self.status() == PetitionFactorsStatus::Finished(PetitionFactorsStatusFinished::Fail)
     }
 
     fn union_of<F, T>(&self, map: F) -> IndexSet<T>

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -173,7 +173,7 @@ impl PetitionEntity {
         assert!(self.references_any_factor_source(&factor_source_ids));
         match self.status() {
             PetitionFactorsStatus::Finished(PetitionFactorsStatusFinished::Fail) => true,
-            PetitionFactorsStatus::Finished(PetitionFactorsStatusFinished::Success) => false, // unsure about this...
+            PetitionFactorsStatus::Finished(PetitionFactorsStatusFinished::Success) => false,
             PetitionFactorsStatus::InProgress => false,
         }
     }

--- a/src/signing/petition_types/petition_entity.rs
+++ b/src/signing/petition_types/petition_entity.rs
@@ -143,10 +143,6 @@ impl PetitionEntity {
         self.both(r#do, |_, _| ())
     }
 
-    pub fn neglect_factor_source_if_referenced(&self, neglected: NeglectedFactor) {
-        self.both_void(|l| l.neglect_if_references(neglected.clone(), true));
-    }
-
     /// # Panics
     /// Panics if this factor source has already been neglected or signed with.
     ///
@@ -202,13 +198,10 @@ impl PetitionEntity {
         let simulation = self.clone();
         for factor_source_id in factor_source_ids.iter() {
             simulation
-                .neglect_if_referenced(
-                    NeglectedFactor::new(
-                        NeglectFactorReason::UserExplicitlySkipped,
-                        *factor_source_id,
-                    ),
-                    true,
-                )
+                .neglect_if_referenced(NeglectedFactor::new(
+                    NeglectFactorReason::Simulation,
+                    *factor_source_id,
+                ))
                 .unwrap();
         }
         simulation.status()
@@ -230,8 +223,8 @@ impl PetitionEntity {
         )
     }
 
-    pub fn neglect_if_referenced(&self, neglected: NeglectedFactor, simulated: bool) -> Result<()> {
-        self.both_void(|p| p.neglect_if_referenced(neglected.clone(), simulated));
+    pub fn neglect_if_referenced(&self, neglected: NeglectedFactor) -> Result<()> {
+        self.both_void(|p| p.neglect_if_referenced(neglected.clone()));
         Ok(())
     }
 

--- a/src/signing/petition_types/petition_factors_types/neglected_factor_instance.rs
+++ b/src/signing/petition_types/petition_factors_types/neglected_factor_instance.rs
@@ -88,4 +88,10 @@ pub enum NeglectFactorReason {
     #[display("Irrelevant")]
     #[debug("Irrelevant")]
     Irrelevant,
+
+    /// We simulate neglect in order to see what the status of petitions
+    /// would be if a FactorSource would be neglected.
+    #[display("Simulation")]
+    #[debug("Simulation")]
+    Simulation,
 }

--- a/src/signing/petition_types/petition_factors_types/neglected_factor_instance.rs
+++ b/src/signing/petition_types/petition_factors_types/neglected_factor_instance.rs
@@ -81,4 +81,11 @@ pub enum NeglectFactorReason {
     #[display("Failure")]
     #[debug("Failure")]
     Failure,
+
+    /// A FactorSource got neglected implicitly since it is irrelevant,
+    /// all transactions which references the FactorSource have already
+    /// failed, thus pointless in using it.
+    #[display("Irrelevant")]
+    #[debug("Irrelevant")]
+    Irrelevant,
 }

--- a/src/signing/petition_types/petition_factors_types/petition_factors.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors.rs
@@ -135,12 +135,6 @@ impl PetitionFactors {
             .is_some()
     }
 
-    pub fn neglect_if_references(&self, neglected: NeglectedFactor) {
-        if self.references_factor_source_with_id(&neglected.factor_source_id()) {
-            self.neglect(neglected)
-        }
-    }
-
     fn expect_reference_to_factor_source_with_id(
         &self,
         factor_source_id: &FactorSourceIDFromHash,

--- a/src/signing/petition_types/petition_factors_types/petition_factors.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors.rs
@@ -73,7 +73,7 @@ impl PetitionFactors {
         ))
     }
 
-    pub fn neglect_if_relevant(&self, neglected: NeglectedFactor, simulated: bool) {
+    pub fn neglect_if_referenced(&self, neglected: NeglectedFactor, simulated: bool) {
         let factor_source_id = &neglected.factor_source_id();
         if let Some(_x_) = self.reference_to_factor_source_with_id(factor_source_id) {
             debug!(

--- a/src/signing/petition_types/petition_factors_types/petition_factors.rs
+++ b/src/signing/petition_types/petition_factors_types/petition_factors.rs
@@ -73,14 +73,14 @@ impl PetitionFactors {
         ))
     }
 
-    pub fn neglect_if_referenced(&self, neglected: NeglectedFactor, simulated: bool) {
+    pub fn neglect_if_referenced(&self, neglected: NeglectedFactor) {
         let factor_source_id = &neglected.factor_source_id();
         if let Some(_x_) = self.reference_to_factor_source_with_id(factor_source_id) {
             debug!(
-                "PetitionFactors = kind {:?} neglect factor source with id: {}, reason: {}, simulated: {}",
-                self.factor_list_kind, factor_source_id, neglected.reason, simulated
+                "PetitionFactors = kind {:?} neglect factor source with id: {}, reason: {}",
+                self.factor_list_kind, factor_source_id, neglected.reason
             );
-            self.neglect(neglected, simulated)
+            self.neglect(neglected)
         } else {
             debug!(
                 "PetitionFactors = kind {:?} did not reference factor source with id: {}",
@@ -89,13 +89,15 @@ impl PetitionFactors {
         }
     }
 
-    fn neglect(&self, neglected: NeglectedFactor, simulated: bool) {
+    fn neglect(&self, neglected: NeglectedFactor) {
         let factor_instance =
             self.expect_reference_to_factor_source_with_id(&neglected.factor_source_id());
-        self.state.borrow_mut().neglect(
-            &NeglectedFactorInstance::new(neglected.reason, factor_instance.clone()),
-            simulated,
-        );
+        self.state
+            .borrow_mut()
+            .neglect(&NeglectedFactorInstance::new(
+                neglected.reason,
+                factor_instance.clone(),
+            ));
     }
 
     pub fn has_owned_instance_with_id(&self, owned_factor_instance: &OwnedFactorInstance) -> bool {
@@ -133,9 +135,9 @@ impl PetitionFactors {
             .is_some()
     }
 
-    pub fn neglect_if_references(&self, neglected: NeglectedFactor, simulated: bool) {
+    pub fn neglect_if_references(&self, neglected: NeglectedFactor) {
         if self.references_factor_source_with_id(&neglected.factor_source_id()) {
-            self.neglect(neglected, simulated)
+            self.neglect(neglected)
         }
     }
 

--- a/src/signing/petition_types/petition_of_transaction.rs
+++ b/src/signing/petition_types/petition_of_transaction.rs
@@ -131,6 +131,10 @@ impl PetitionTransaction {
         &self,
         factor_source_ids: IndexSet<FactorSourceIDFromHash>,
     ) -> IndexSet<InvalidTransactionIfNeglected> {
+        if self.has_tx_failed() {
+            // No need to display already failed tx.
+            return IndexSet::new();
+        }
         self.for_entities
             .borrow()
             .iter()

--- a/src/signing/petition_types/petition_of_transaction.rs
+++ b/src/signing/petition_types/petition_of_transaction.rs
@@ -89,10 +89,10 @@ impl PetitionTransaction {
         for_entity.add_signature(signature.clone());
     }
 
-    pub fn neglected_factor_source(&self, neglected: NeglectedFactor) {
+    pub fn neglect_factor_source(&self, neglected: NeglectedFactor) {
         let mut for_entities = self.for_entities.borrow_mut();
         for petition in for_entities.values_mut() {
-            petition.neglected_factor_source_if_relevant(neglected.clone())
+            petition.neglect_factor_source_if_referenced(neglected.clone())
         }
     }
 
@@ -118,6 +118,21 @@ impl PetitionTransaction {
                 petition.invalid_transactions_if_neglected_factors(factor_source_ids.clone())
             })
             .collect()
+    }
+
+    pub(crate) fn should_neglect_factors_due_to_irrelevant(
+        &self,
+        factor_source_ids: IndexSet<FactorSourceIDFromHash>,
+    ) -> bool {
+        self.for_entities
+            .borrow()
+            .values()
+            .cloned()
+            .into_iter()
+            .filter(|p| p.references_any_factor_source(&factor_source_ids))
+            .all(|petition| {
+                petition.should_neglect_factors_due_to_irrelevant(factor_source_ids.clone())
+            })
     }
 
     #[allow(unused)]

--- a/src/signing/petition_types/petition_of_transaction.rs
+++ b/src/signing/petition_types/petition_of_transaction.rs
@@ -92,7 +92,7 @@ impl PetitionTransaction {
     pub fn neglect_factor_source(&self, neglected: NeglectedFactor) {
         let mut for_entities = self.for_entities.borrow_mut();
         for petition in for_entities.values_mut() {
-            petition.neglect_factor_source_if_referenced(neglected.clone())
+            petition.neglect_if_referenced(neglected.clone()).unwrap()
         }
     }
 

--- a/src/signing/petition_types/petitions.rs
+++ b/src/signing/petition_types/petitions.rs
@@ -178,10 +178,14 @@ impl Petitions {
 
         let per_transaction = intent_hashes
             .into_iter()
-            .map(|intent_hash| {
+            .filter_map(|intent_hash| {
                 let binding = self.txid_to_petition.borrow();
                 let petition = binding.get(intent_hash).unwrap();
-                petition.input_for_interactor(factor_source_id)
+                if petition.has_tx_failed() {
+                    None
+                } else {
+                    Some(petition.input_for_interactor(factor_source_id))
+                }
             })
             .collect::<IndexSet<BatchKeySigningRequest>>();
 

--- a/src/signing/petition_types/petitions.rs
+++ b/src/signing/petition_types/petitions.rs
@@ -161,6 +161,12 @@ impl Petitions {
             })
     }
 
+    /// # Panics
+    /// Panics if no petition deem usage of `FactorSource` with id
+    /// `factor_source_id` relevant. We SHOULD have checked this already with
+    /// `should_neglect_factors_due_to_irrelevant` from SignatureCollector main
+    /// loop, i.e. we should not have called this method from SignaturesCollector
+    /// if `should_neglect_factors_due_to_irrelevant` returned true.
     pub(crate) fn input_for_interactor(
         &self,
         factor_source_id: &FactorSourceIDFromHash,
@@ -169,6 +175,7 @@ impl Petitions {
             .factor_source_to_intent_hash
             .get(factor_source_id)
             .unwrap();
+
         let per_transaction = intent_hashes
             .into_iter()
             .map(|intent_hash| {

--- a/src/signing/signatures_outcome_types/sign_with_factors_outcome.rs
+++ b/src/signing/signatures_outcome_types/sign_with_factors_outcome.rs
@@ -10,7 +10,7 @@ pub enum SignWithFactorsOutcome {
     },
 
     /// The factor source got neglected, either due to user explicitly skipping
-    /// or due to failire
+    /// or due to failure
     #[debug("Neglected")]
     Neglected(NeglectedFactors),
 }
@@ -35,5 +35,16 @@ impl SignWithFactorsOutcome {
 
     pub fn user_skipped_factor(id: FactorSourceIDFromHash) -> Self {
         Self::user_skipped_factors(IndexSet::from_iter([id]))
+    }
+
+    pub fn irrelevant(factor_sources_of_kind: &FactorSourcesOfKind) -> Self {
+        Self::Neglected(NeglectedFactors::new(
+            NeglectFactorReason::Irrelevant,
+            factor_sources_of_kind
+                .factor_sources()
+                .into_iter()
+                .map(|f| f.factor_source_id())
+                .collect(),
+        ))
     }
 }

--- a/src/signing/signatures_outcome_types/signatures_outcome.rs
+++ b/src/signing/signatures_outcome_types/signatures_outcome.rs
@@ -112,6 +112,12 @@ impl SignaturesOutcome {
         self.ids_of_neglected_factor_sources_filter(|nf| nf.reason == NeglectFactorReason::Failure)
     }
 
+    pub fn ids_of_neglected_factor_sources_irrelevant(&self) -> IndexSet<FactorSourceIDFromHash> {
+        self.ids_of_neglected_factor_sources_filter(|nf| {
+            nf.reason == NeglectFactorReason::Irrelevant
+        })
+    }
+
     pub fn signatures_of_failed_transactions(&self) -> IndexSet<HDSignature> {
         self.failed_transactions.all_signatures()
     }

--- a/src/testing/signing/simulated_user.rs
+++ b/src/testing/signing/simulated_user.rs
@@ -131,6 +131,7 @@ impl SimulatedUser {
             .into_iter()
             .collect::<std::collections::HashSet<_>>();
 
+        println!("🚀 call spy");
         (self.spy_on_request)(factor_source_kind, invalid_tx_if_skipped.clone());
 
         if self.be_prudent(|| !invalid_tx_if_skipped.is_empty()) {

--- a/src/testing/signing/simulated_user.rs
+++ b/src/testing/signing/simulated_user.rs
@@ -107,6 +107,7 @@ impl SimulatedUser {
 }
 
 unsafe impl Sync for SimulatedUser {}
+unsafe impl Send for SimulatedUser {}
 
 /// A very lazy user that defers all boring work such as signing stuff for as long
 /// as possible. Ironically, this sometimes leads to user signing more than she

--- a/src/testing/signing/simulated_user.rs
+++ b/src/testing/signing/simulated_user.rs
@@ -17,8 +17,7 @@ pub struct SimulatedUser {
 
 impl SimulatedUser {
     pub fn with_spy(
-        spy_on_request: impl Fn(FactorSourceKind, IndexSet<InvalidTransactionIfNeglected>)
-            + 'static,
+        spy_on_request: impl Fn(FactorSourceKind, IndexSet<InvalidTransactionIfNeglected>) + 'static,
         mode: SimulatedUserMode,
         failures: impl Into<Option<SimulatedFailures>>,
     ) -> Self {

--- a/src/testing/signing/test_data.rs
+++ b/src/testing/signing/test_data.rs
@@ -219,6 +219,14 @@ impl MatrixOfFactorInstances {
             5,
         )
     }
+    /// Securified { Threshold 1/1 and Override factors #1  }
+    pub fn m8<F>(fi: F) -> Self
+    where
+        F: Fn(FactorSourceIDFromHash) -> HierarchicalDeterministicFactorInstance,
+    {
+        type F = FactorSourceIDFromHash;
+        Self::new([F::fs1()].map(&fi), 1, [F::fs8()].map(&fi))
+    }
 }
 
 impl Account {
@@ -295,6 +303,16 @@ impl Account {
     /// Jenny | 8 | Unsecurified { Device } (fs10)
     pub fn a8() -> Self {
         Self::unsecurified_mainnet(8, "Jenny", FactorSourceIDFromHash::fs10())
+    }
+
+    /// Klara | 9 |  Securified { Threshold 1/1 and Override factors #1  }
+    pub fn a9() -> Self {
+        Self::securified_mainnet(9, "Klara", |idx| {
+            MatrixOfFactorInstances::m8(HierarchicalDeterministicFactorInstance::f(
+                Self::entity_kind(),
+                idx,
+            ))
+        })
     }
 }
 

--- a/src/testing/signing/test_interactors/test_parallel_interactor.rs
+++ b/src/testing/signing/test_interactors/test_parallel_interactor.rs
@@ -20,6 +20,10 @@ impl IsTestInteractor for TestSigningParallelInteractor {
 #[async_trait::async_trait]
 impl SignWithFactorParallelInteractor for TestSigningParallelInteractor {
     async fn sign(&self, request: ParallelBatchSigningRequest) -> SignWithFactorsOutcome {
+        self.simulated_user.spy_on_request_before_handled(
+            request.clone().factor_source_kind(),
+            request.clone().invalid_transactions_if_neglected,
+        );
         let ids = request
             .per_factor_source
             .keys()
@@ -30,10 +34,10 @@ impl SignWithFactorParallelInteractor for TestSigningParallelInteractor {
             return SignWithFactorsOutcome::failure_with_factors(ids);
         }
 
-        match self.simulated_user.sign_or_skip(
-            request.factor_source_kind(),
-            request.invalid_transactions_if_neglected,
-        ) {
+        match self
+            .simulated_user
+            .sign_or_skip(request.invalid_transactions_if_neglected)
+        {
             SigningUserInput::Sign => {
                 let signatures = request
                     .per_factor_source

--- a/src/testing/signing/test_interactors/test_parallel_interactor.rs
+++ b/src/testing/signing/test_interactors/test_parallel_interactor.rs
@@ -30,10 +30,10 @@ impl SignWithFactorParallelInteractor for TestSigningParallelInteractor {
             return SignWithFactorsOutcome::failure_with_factors(ids);
         }
 
-        match self
-            .simulated_user
-            .sign_or_skip(request.invalid_transactions_if_neglected)
-        {
+        match self.simulated_user.sign_or_skip(
+            request.factor_source_kind(),
+            request.invalid_transactions_if_neglected,
+        ) {
             SigningUserInput::Sign => {
                 let signatures = request
                     .per_factor_source

--- a/src/testing/signing/test_interactors/test_serial_interactor.rs
+++ b/src/testing/signing/test_interactors/test_serial_interactor.rs
@@ -20,15 +20,20 @@ impl IsTestInteractor for TestSigningSerialInteractor {
 #[async_trait::async_trait]
 impl SignWithFactorSerialInteractor for TestSigningSerialInteractor {
     async fn sign(&self, request: SerialBatchSigningRequest) -> SignWithFactorsOutcome {
+        self.simulated_user.spy_on_request_before_handled(
+            request.clone().factor_source_kind(),
+            request.clone().invalid_transactions_if_neglected,
+        );
         let ids = IndexSet::from_iter([request.clone().input.factor_source_id]);
         if self.should_simulate_failure(ids.clone()) {
             return SignWithFactorsOutcome::failure_with_factors(ids);
         }
         let invalid_transactions_if_neglected = request.clone().invalid_transactions_if_neglected;
-        match self.simulated_user.sign_or_skip(
-            request.factor_source_kind(),
-            invalid_transactions_if_neglected,
-        ) {
+
+        match self
+            .simulated_user
+            .sign_or_skip(invalid_transactions_if_neglected)
+        {
             SigningUserInput::Sign => {
                 let signatures = request
                     .input

--- a/src/testing/signing/test_interactors/test_serial_interactor.rs
+++ b/src/testing/signing/test_interactors/test_serial_interactor.rs
@@ -20,15 +20,15 @@ impl IsTestInteractor for TestSigningSerialInteractor {
 #[async_trait::async_trait]
 impl SignWithFactorSerialInteractor for TestSigningSerialInteractor {
     async fn sign(&self, request: SerialBatchSigningRequest) -> SignWithFactorsOutcome {
-        let ids = IndexSet::from_iter([request.input.factor_source_id]);
+        let ids = IndexSet::from_iter([request.clone().input.factor_source_id]);
         if self.should_simulate_failure(ids.clone()) {
             return SignWithFactorsOutcome::failure_with_factors(ids);
         }
-        let invalid_transactions_if_neglected = request.invalid_transactions_if_neglected;
-        match self
-            .simulated_user
-            .sign_or_skip(invalid_transactions_if_neglected)
-        {
+        let invalid_transactions_if_neglected = request.clone().invalid_transactions_if_neglected;
+        match self.simulated_user.sign_or_skip(
+            request.factor_source_kind(),
+            invalid_transactions_if_neglected,
+        ) {
             SigningUserInput::Sign => {
                 let signatures = request
                     .input

--- a/src/types/invalid_transaction_if_neglected.rs
+++ b/src/types/invalid_transaction_if_neglected.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 /// A list of entities which would fail in a transaction if we would
-/// neglect certain factor source, either by user explictlty skipping
+/// neglect certain factor source, either by user explicitly skipping
 /// it or if implicitly neglected due to failure.
 #[derive(Clone, Debug, PartialEq, Eq, std::hash::Hash)]
 pub struct InvalidTransactionIfNeglected {

--- a/src/types/owned_types/owned_factor_instance.rs
+++ b/src/types/owned_types/owned_factor_instance.rs
@@ -19,11 +19,15 @@ impl OwnedFactorInstance {
         &self.value
     }
 
+    pub fn factor_source_id(&self) -> FactorSourceIDFromHash {
+        self.factor_instance().factor_source_id()
+    }
+
     /// Checks if this `OwnedFactorInstance` was created from the factor source
     /// with id `factor_source_id`.
     pub fn by_factor_source(&self, factor_source_id: impl Borrow<FactorSourceIDFromHash>) -> bool {
         let factor_source_id = factor_source_id.borrow();
-        self.factor_instance().factor_source_id == *factor_source_id
+        self.factor_source_id() == *factor_source_id
     }
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -800,6 +800,30 @@ mod signing_tests {
                     vec![tx.intent_hash]
                 )
             }
+
+            #[actix_rt::test]
+            async fn same_tx_is_not_shown_to_user_in_case_of_already_failure() {
+                let factor_sources = HDFactorSource::all();
+                let tx0 = TransactionIntent::new([], []);
+                let tx1 = TransactionIntent::new([], []);
+                let profile = Profile::new(factor_sources.clone(), [], []);
+                let collector = SignaturesCollector::new(
+                    SigningFinishEarlyStrategy::default(),
+                    IndexSet::from_iter([tx0, tx1]),
+                    Arc::new(TestSignatureCollectingInteractors::new(
+                        SimulatedUser::prudent_with_failures(
+                            SimulatedFailures::with_simulated_failures([
+                                FactorSourceIDFromHash::fs0(),
+                            ]),
+                        ),
+                    )),
+                    &profile,
+                )
+                .unwrap();
+
+                let outcome = collector.collect_signatures().await;
+                todo!()
+            }
         }
 
         mod no_fail {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -801,6 +801,7 @@ mod signing_tests {
                 )
             }
 
+            #[ignore = "WIP"]
             #[actix_rt::test]
             async fn same_tx_is_not_shown_to_user_in_case_of_already_failure() {
                 let factor_sources = HDFactorSource::all();

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -804,6 +804,7 @@ mod signing_tests {
             #[ignore = "WIP"]
             #[actix_rt::test]
             async fn same_tx_is_not_shown_to_user_in_case_of_already_failure() {
+                sensible_env_logger::safe_init!();
                 let factor_sources = HDFactorSource::all();
 
                 let a7 = Account::a7();
@@ -812,9 +813,10 @@ mod signing_tests {
                 let tx0 = TransactionIntent::new([a7.entity_address(), a0.entity_address()], []);
                 let tx1 = TransactionIntent::new([a0.entity_address()], []);
 
+                info!("tx0: {:?}", tx0.intent_hash);
+                info!("tx1: {:?}", tx1.intent_hash);
                 let profile = Profile::new(factor_sources.clone(), [&a7, &a0], []);
 
-                sensible_env_logger::safe_init!();
                 let collector = SignaturesCollector::new(
                     SigningFinishEarlyStrategy::default(),
                     IndexSet::from_iter([tx0.clone(), tx1.clone()]),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -812,8 +812,8 @@ mod signing_tests {
                 let tx0 = TransactionIntent::new([a7.entity_address(), a0.entity_address()], []);
                 let tx1 = TransactionIntent::new([a0.entity_address()], []);
 
-                info!("tx0: {:?}", tx0.intent_hash);
-                info!("tx1: {:?}", tx1.intent_hash);
+                info!("tx0: {:?} (Should FAIL)", tx0.intent_hash);
+                info!("tx1: {:?} (Should SUCCEED)", tx1.intent_hash);
                 let profile = Profile::new(factor_sources.clone(), [&a7, &a0], []);
 
                 let collector = SignaturesCollector::new(

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -804,6 +804,8 @@ mod signing_tests {
             #[actix_rt::test]
             async fn same_tx_is_not_shown_to_user_in_case_of_already_failure() {
                 let factor_sources = HDFactorSource::all();
+
+                let a = Account::a0();
                 let tx0 = TransactionIntent::new([], []);
                 let tx1 = TransactionIntent::new([], []);
                 let profile = Profile::new(factor_sources.clone(), [], []);
@@ -822,7 +824,14 @@ mod signing_tests {
                 .unwrap();
 
                 let outcome = collector.collect_signatures().await;
-                todo!()
+                assert!(outcome.successful());
+                assert_eq!(
+                    outcome
+                        .ids_of_neglected_factor_sources_irrelevant()
+                        .into_iter()
+                        .collect_vec(),
+                    vec![]
+                );
             }
         }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -801,7 +801,6 @@ mod signing_tests {
                 )
             }
 
-            #[ignore = "WIP"]
             #[actix_rt::test]
             async fn same_tx_is_not_shown_to_user_in_case_of_already_failure() {
                 sensible_env_logger::safe_init!();


### PR DESCRIPTION
Ensure we:
* **Do NOT** continue appending signatures to already failed transactions
* **Do NOT** display already failed transactions in list of `InvalidTransactionsIfNeglected`